### PR TITLE
Bug/scheduler dropdown update cron

### DIFF
--- a/apps/dokploy/components/dashboard/application/schedules/handle-schedules.tsx
+++ b/apps/dokploy/components/dashboard/application/schedules/handle-schedules.tsx
@@ -409,12 +409,10 @@ export const HandleSchedules = ({ id, scheduleId, scheduleType }: Props) => {
 									</FormLabel>
 									<div className="flex flex-col gap-2">
 										<Select
-											value={getSelectValue(field.value)}  // Add this line!
+											value={getSelectValue(field.value)}  
 											onValueChange={(value) => {
 												field.onChange(value);
-											}}
-
-										>
+											}}>
 											<FormControl>
 												<SelectTrigger>
 													<SelectValue placeholder="Select a predefined schedule" />

--- a/apps/dokploy/components/dashboard/application/schedules/handle-schedules.tsx
+++ b/apps/dokploy/components/dashboard/application/schedules/handle-schedules.tsx
@@ -56,6 +56,7 @@ export const commonCronExpressions = [
 	{ label: "Every month on the 1st at midnight", value: "0 0 1 * *" },
 	{ label: "Every 15 minutes", value: "*/15 * * * *" },
 	{ label: "Every weekday at midnight", value: "0 0 * * 1-5" },
+	{ label: "Custom", value: "custom"}
 ];
 
 const formSchema = z
@@ -113,6 +114,17 @@ interface Props {
 	scheduleId?: string;
 	scheduleType?: "application" | "compose" | "server" | "dokploy-server";
 }
+
+const getSelectValue = (cronExpression: string) => {
+	if (cronExpression === "") {
+		return "";
+	}
+  const match = commonCronExpressions.find((expr) => 
+	expr.value === cronExpression);
+
+  return match ? match.value : "custom";
+
+};
 
 export const HandleSchedules = ({ id, scheduleId, scheduleType }: Props) => {
 	const [isOpen, setIsOpen] = useState(false);
@@ -397,9 +409,11 @@ export const HandleSchedules = ({ id, scheduleId, scheduleType }: Props) => {
 									</FormLabel>
 									<div className="flex flex-col gap-2">
 										<Select
+											value={getSelectValue(field.value)}  // Add this line!
 											onValueChange={(value) => {
 												field.onChange(value);
 											}}
+
 										>
 											<FormControl>
 												<SelectTrigger>


### PR DESCRIPTION
## Issue Addressed: Scheduler dropdown does not update with custom cron expression

## Solution:
- Added a getSelectValue function that searches through the `commonCronExpression` array to check if the typed expression matches a predefined one. 
-  If it does not, then the option on the dropdow automatically switches to `Custom`
- If the value typed matches a predefined expression, then the dropdown will match it accordingly.

## Before:
<img width="639" height="331" alt="Screenshot 2025-11-23 at 10 49 54 PM" src="https://github.com/user-attachments/assets/d5f67f2a-a9d2-439c-b2d0-21db076fbb4c" />
<img width="639" height="331" alt="Screenshot 2025-11-23 at 10 50 18 PM" src="https://github.com/user-attachments/assets/27c51e7d-46b0-4305-a5e2-2ce65f535419" />



## After:
<img width="639" height="331" alt="Screenshot 2025-11-23 at 10 50 58 PM" src="https://github.com/user-attachments/assets/1102a4ff-e951-4ff7-b0e8-ce3d22d7a493" />
<img width="639" height="331" alt="Screenshot 2025-11-23 at 10 51 10 PM" src="https://github.com/user-attachments/assets/96ab5307-83c0-4ac3-95d6-0e0d8c0ee878" />



## Demo
https://github.com/user-attachments/assets/ffe9cf2e-3d02-4588-8112-4806af851e27



#18 