### PR TITLE
Feature/custom title description api cli deployments

### DIFF
--- a/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
+++ b/apps/dokploy/components/dashboard/application/deployments/show-deployments.tsx
@@ -132,22 +132,27 @@ export const ShowDeployments = ({
 								key={deployment.deploymentId}
 								className="flex items-center justify-between rounded-lg border p-4 gap-2"
 							>
-								<div className="flex flex-col">
-									<span className="flex items-center gap-4 font-medium capitalize text-foreground">
-										{index + 1}. {deployment.status}
+								<div className="flex flex-col gap-1">
+									<div className="flex items-center gap-2">
+										<span className="font-semibold text-base text-foreground">
+											{deployment.title}
+										</span>
 										<StatusTooltip
 											status={deployment?.status}
 											className="size-2.5"
 										/>
-									</span>
-									<span className="text-sm text-muted-foreground">
-										{deployment.title}
-									</span>
+									</div>
 									{deployment.description && (
-										<span className="break-all text-sm text-muted-foreground">
+										<span className="text-sm text-muted-foreground">
 											{deployment.description}
 										</span>
 									)}
+									<span className="text-xs text-muted-foreground capitalize flex items-center gap-2">
+										<Badge variant="secondary" className="text-[10px]">
+											{index + 1}
+										</Badge>
+										Status: {deployment.status}
+									</span>
 								</div>
 								<div className="flex flex-col items-end gap-2">
 									<div className="text-sm capitalize text-muted-foreground flex items-center gap-2">

--- a/apps/dokploy/components/dashboard/application/schedules/handle-schedules.tsx
+++ b/apps/dokploy/components/dashboard/application/schedules/handle-schedules.tsx
@@ -409,12 +409,10 @@ export const HandleSchedules = ({ id, scheduleId, scheduleType }: Props) => {
 									</FormLabel>
 									<div className="flex flex-col gap-2">
 										<Select
-											value={getSelectValue(field.value)}  // Add this line!
+											value={getSelectValue(field.value)}  
 											onValueChange={(value) => {
 												field.onChange(value);
-											}}
-
-										>
+											}}>
 											<FormControl>
 												<SelectTrigger>
 													<SelectValue placeholder="Select a predefined schedule" />

--- a/apps/dokploy/components/dashboard/application/schedules/handle-schedules.tsx
+++ b/apps/dokploy/components/dashboard/application/schedules/handle-schedules.tsx
@@ -56,6 +56,7 @@ export const commonCronExpressions = [
 	{ label: "Every month on the 1st at midnight", value: "0 0 1 * *" },
 	{ label: "Every 15 minutes", value: "*/15 * * * *" },
 	{ label: "Every weekday at midnight", value: "0 0 * * 1-5" },
+	{ label: "Custom", value: "custom"}
 ];
 
 const formSchema = z
@@ -113,6 +114,17 @@ interface Props {
 	scheduleId?: string;
 	scheduleType?: "application" | "compose" | "server" | "dokploy-server";
 }
+
+const getSelectValue = (cronExpression: string) => {
+	if (cronExpression === "") {
+		return "";
+	}
+  const match = commonCronExpressions.find((expr) => 
+	expr.value === cronExpression);
+
+  return match ? match.value : "custom";
+
+};
 
 export const HandleSchedules = ({ id, scheduleId, scheduleType }: Props) => {
 	const [isOpen, setIsOpen] = useState(false);
@@ -397,9 +409,11 @@ export const HandleSchedules = ({ id, scheduleId, scheduleType }: Props) => {
 									</FormLabel>
 									<div className="flex flex-col gap-2">
 										<Select
+											value={getSelectValue(field.value)}  // Add this line!
 											onValueChange={(value) => {
 												field.onChange(value);
 											}}
+
 										>
 											<FormControl>
 												<SelectTrigger>

--- a/apps/dokploy/server/api/routers/application.ts
+++ b/apps/dokploy/server/api/routers/application.ts
@@ -6,6 +6,7 @@ import {
 import { db } from "@/server/db";
 import {
 	apiCreateApplication,
+	apiDeploymentTitleAndDescription,
 	apiFindMonitoringStats,
 	apiFindOneApplication,
 	apiReloadApplication,
@@ -298,7 +299,7 @@ export const applicationRouter = createTRPCRouter({
 		}),
 
 	redeploy: protectedProcedure
-		.input(apiFindOneApplication)
+		.input(apiFindOneApplication.merge(apiDeploymentTitleAndDescription))
 		.mutation(async ({ input, ctx }) => {
 			const application = await findApplicationById(input.applicationId);
 			if (
@@ -311,8 +312,8 @@ export const applicationRouter = createTRPCRouter({
 			}
 			const jobData: DeploymentJob = {
 				applicationId: input.applicationId,
-				titleLog: "Rebuild deployment",
-				descriptionLog: "",
+				titleLog: input.title || "Rebuild deployment",
+				descriptionLog: input.description || "",
 				type: "redeploy",
 				applicationType: "application",
 				server: !!application.serverId,
@@ -648,7 +649,7 @@ export const applicationRouter = createTRPCRouter({
 			return true;
 		}),
 	deploy: protectedProcedure
-		.input(apiFindOneApplication)
+		.input(apiFindOneApplication.merge(apiDeploymentTitleAndDescription))
 		.mutation(async ({ input, ctx }) => {
 			const application = await findApplicationById(input.applicationId);
 			if (
@@ -661,8 +662,8 @@ export const applicationRouter = createTRPCRouter({
 			}
 			const jobData: DeploymentJob = {
 				applicationId: input.applicationId,
-				titleLog: "Manual deployment",
-				descriptionLog: "",
+				titleLog: input.title || "Manual deployment",
+				descriptionLog: input.description || "",
 				type: "deploy",
 				applicationType: "application",
 				server: !!application.serverId,

--- a/apps/dokploy/server/api/routers/compose.ts
+++ b/apps/dokploy/server/api/routers/compose.ts
@@ -3,6 +3,7 @@ import { db } from "@/server/db";
 import {
 	apiCreateCompose,
 	apiDeleteCompose,
+	apiDeploymentTitleAndDescription,
 	apiFetchServices,
 	apiFindCompose,
 	apiRandomizeCompose,
@@ -315,7 +316,7 @@ export const composeRouter = createTRPCRouter({
 		}),
 
 	deploy: protectedProcedure
-		.input(apiFindCompose)
+		.input(apiFindCompose.merge(apiDeploymentTitleAndDescription))
 		.mutation(async ({ input, ctx }) => {
 			const compose = await findComposeById(input.composeId);
 
@@ -327,10 +328,10 @@ export const composeRouter = createTRPCRouter({
 			}
 			const jobData: DeploymentJob = {
 				composeId: input.composeId,
-				titleLog: "Manual deployment",
+				titleLog: input.title || "Manual deployment",
 				type: "deploy",
 				applicationType: "compose",
-				descriptionLog: "",
+				descriptionLog: input.description || "",
 				server: !!compose.serverId,
 			};
 
@@ -349,7 +350,7 @@ export const composeRouter = createTRPCRouter({
 			);
 		}),
 	redeploy: protectedProcedure
-		.input(apiFindCompose)
+		.input(apiFindCompose.merge(apiDeploymentTitleAndDescription))
 		.mutation(async ({ input, ctx }) => {
 			const compose = await findComposeById(input.composeId);
 			if (compose.project.organizationId !== ctx.session.activeOrganizationId) {
@@ -360,10 +361,10 @@ export const composeRouter = createTRPCRouter({
 			}
 			const jobData: DeploymentJob = {
 				composeId: input.composeId,
-				titleLog: "Rebuild deployment",
+				titleLog: input.title || "Rebuild deployment",
 				type: "redeploy",
 				applicationType: "compose",
-				descriptionLog: "",
+				descriptionLog: input.description || "",
 				server: !!compose.serverId,
 			};
 			if (IS_CLOUD && compose.serverId) {

--- a/apps/dokploy/server/queues/queue-types.ts
+++ b/apps/dokploy/server/queues/queue-types.ts
@@ -1,7 +1,15 @@
+/**
+ * Job data for deployment queue
+ *
+ * Contains all information needed to execute a deployment, including custom
+ * titles and descriptions for tracking deployment history.
+ */
 type DeployJob =
 	| {
 			applicationId: string;
+			/** Deployment title shown in UI (custom or default "Manual deployment"/"Rebuild deployment") */
 			titleLog: string;
+			/** Optional deployment description providing additional context */
 			descriptionLog: string;
 			server?: boolean;
 			type: "deploy" | "redeploy";
@@ -10,7 +18,9 @@ type DeployJob =
 	  }
 	| {
 			composeId: string;
+			/** Deployment title shown in UI (custom or default "Manual deployment"/"Rebuild deployment") */
 			titleLog: string;
+			/** Optional deployment description providing additional context */
 			descriptionLog: string;
 			server?: boolean;
 			type: "deploy" | "redeploy";
@@ -19,7 +29,9 @@ type DeployJob =
 	  }
 	| {
 			applicationId: string;
+			/** Deployment title shown in UI (custom or default "Manual deployment"/"Rebuild deployment") */
 			titleLog: string;
+			/** Optional deployment description providing additional context */
 			descriptionLog: string;
 			server?: boolean;
 			type: "deploy";
@@ -28,4 +40,24 @@ type DeployJob =
 			serverId?: string;
 	  };
 
+/**
+ * Deployment job type for Bull queue
+ *
+ * Supports custom titles and descriptions for all deployment types:
+ * - Application deployments (deploy/redeploy)
+ * - Compose service deployments (deploy/redeploy)
+ * - Preview deployments
+ *
+ * @example
+ * ```typescript
+ * const job: DeploymentJob = {
+ *   applicationId: "abc123",
+ *   titleLog: "Hotfix: Fix login bug",
+ *   descriptionLog: "Emergency fix for authentication issue",
+ *   type: "deploy",
+ *   applicationType: "application",
+ *   server: false
+ * };
+ * ```
+ */
 export type DeploymentJob = DeployJob;

--- a/apps/dokploy/server/queues/queue-types.ts
+++ b/apps/dokploy/server/queues/queue-types.ts
@@ -1,15 +1,8 @@
-/**
- * Job data for deployment queue
- *
- * Contains all information needed to execute a deployment, including custom
- * titles and descriptions for tracking deployment history.
- */
+
 type DeployJob =
 	| {
 			applicationId: string;
-			/** Deployment title shown in UI (custom or default "Manual deployment"/"Rebuild deployment") */
 			titleLog: string;
-			/** Optional deployment description providing additional context */
 			descriptionLog: string;
 			server?: boolean;
 			type: "deploy" | "redeploy";
@@ -18,9 +11,7 @@ type DeployJob =
 	  }
 	| {
 			composeId: string;
-			/** Deployment title shown in UI (custom or default "Manual deployment"/"Rebuild deployment") */
 			titleLog: string;
-			/** Optional deployment description providing additional context */
 			descriptionLog: string;
 			server?: boolean;
 			type: "deploy" | "redeploy";
@@ -29,9 +20,7 @@ type DeployJob =
 	  }
 	| {
 			applicationId: string;
-			/** Deployment title shown in UI (custom or default "Manual deployment"/"Rebuild deployment") */
 			titleLog: string;
-			/** Optional deployment description providing additional context */
 			descriptionLog: string;
 			server?: boolean;
 			type: "deploy";
@@ -40,24 +29,4 @@ type DeployJob =
 			serverId?: string;
 	  };
 
-/**
- * Deployment job type for Bull queue
- *
- * Supports custom titles and descriptions for all deployment types:
- * - Application deployments (deploy/redeploy)
- * - Compose service deployments (deploy/redeploy)
- * - Preview deployments
- *
- * @example
- * ```typescript
- * const job: DeploymentJob = {
- *   applicationId: "abc123",
- *   titleLog: "Hotfix: Fix login bug",
- *   descriptionLog: "Emergency fix for authentication issue",
- *   type: "deploy",
- *   applicationType: "application",
- *   server: false
- * };
- * ```
- */
 export type DeploymentJob = DeployJob;

--- a/packages/server/src/db/schema/deployment.ts
+++ b/packages/server/src/db/schema/deployment.ts
@@ -106,6 +106,17 @@ const schema = createInsertSchema(deployments, {
 	previewDeploymentId: z.string(),
 });
 
+export const apiDeploymentTitleAndDescription = z.object({
+	title: z
+		.string()
+		.max(200, "Title must be 200 characters or less")
+		.optional(),
+	description: z
+		.string()
+		.max(2000, "Description must be 2000 characters or less")
+		.optional(),
+});
+
 export const apiCreateDeployment = schema
 	.pick({
 		title: true,


### PR DESCRIPTION
## Issue Addressed: Issue #7 - [FEATURE] Add custom title/description support for API/CLI deployments 

## Solution: 
- Created a Zod schema with optional fields of title and description to be merged into the current input schema for API endpoints. 
```
apiDeploymentTitleAndDescription = z.object({
	title: z
		.string()
		.max(200, "Title must be 200 characters or less")
		.optional(),
	description: z
		.string()
		.max(2000, "Description must be 2000 characters or less")
		.optional(),
});
```
- The new Zod schema is merged into the deployment and redeployment API endpoints by doing:
```
.input(apiFindOneApplication.merge(apiDeploymentTitleAndDescription))
.input(apiFindOneApplication.merge(apiDeploymentTitleAndDescription))
```

## Before:
<img width="488" height="274" alt="Screenshot 2025-11-30 at 11 18 13 PM" src="https://github.com/user-attachments/assets/b506eba8-5bac-40c3-8e3e-3087be85ca6d" />



## After:
<img width="488" height="274" alt="Screenshot 2025-11-30 at 11 18 30 PM" src="https://github.com/user-attachments/assets/e5c03b70-629f-45f0-a891-27873a7f5a82" />




## Demo

https://github.com/user-attachments/assets/ec759161-1393-42e6-833c-d00f900f3838



#11 